### PR TITLE
Adding Electron 1.4 and 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 install:
   - if [[ -n "$ELECTRON" ]]; then
       export npm_config_target=$ELECTRON;
-      export npm_config_disturl=https://atom.io/download/atom-shell;
+      export npm_config_disturl=https://atom.io/download/electron;
       export npm_config_runtime=electron;
       export npm_config_build_from_source=true;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,25 @@ matrix:
       env: NODE_VERSION="6" CXX="g++-4.9"
     - os: linux   # abi 49
       env: NODE_VERSION="6" ELECTRON="1.3.6" CXX="g++-4.9"
+    - os: linux   # abi 50
+      env: NODE_VERSION="6.5" ELECTRON="1.4.16" CXX="g++-4.9"
     - os: linux   # abi 51
       env: NODE_VERSION="7" CXX="g++-4.9"
+    - os: linux   # abi 53
+      env: NODE_VERSION="7.4" ELECTRON="1.6.5" CXX="g++-4.9"
     # os x x86
-    - os: osx
+    - os: osx     # abi 47
       env: NODE_VERSION="5.1.1" CXX="clang"
-    - os: osx
+    - os: osx     # abi 48
       env: NODE_VERSION="6" CXX="clang"
-    - os: osx
+    - os: osx     # abi 49
       env: NODE_VERSION="6" ELECTRON="1.3.6" CXX="clang"
-    - os: osx
+    - os: osx     # abi 50
+      env: NODE_VERSION="6.5" ELECTRON="1.4.16" CXX="clang"
+    - os: osx     # abi 51
       env: NODE_VERSION="7" CXX="clang"
+    - os: osx     # abi 53
+      env: NODE_VERSION="7.4" ELECTRON="1.6.5" CXX="clang"
 
 before_install:
   - rm -rf ~/.nvm/ && git clone --depth 1 "https://github.com/creationix/nvm.git" ~/.nvm

--- a/find-binary.js
+++ b/find-binary.js
@@ -6,10 +6,22 @@ var path = require('path');
 module.exports = function findBinary(packageJsonPath) {
   var pack = JSON.parse(fs.readFileSync(packageJsonPath));
 
-  // ABI v49 is only for Electron. https://github.com/electron/electron/issues/5851
-  var nodeAbi = process.versions.modules === '49'
-    ? 'electron-v1.3'
-    : 'node-v' + process.versions.modules;
+  // ABI v49, v50 and v53 are only for Electron. https://github.com/electron/electron/issues/5851
+  var nodeAbi = '';
+  
+  switch(process.versions.modules) {
+    case '49':
+      nodeAbi = 'electron-v1.3';
+      break;
+    case '50':
+      nodeAbi = 'electron-v1.4';
+      break;
+    case '53':
+      nodeAbi = 'electron-v1.6';
+      break;
+    default:
+      nodeAbi = 'node-v' + process.versions.modules;
+  }
 
   var modulePath = pack.binary.module_path
     .replace('{module_name}', pack.binary.module_name)

--- a/find-binary.js
+++ b/find-binary.js
@@ -10,13 +10,13 @@ module.exports = function findBinary(packageJsonPath) {
   var nodeAbi = '';
   
   switch(process.versions.modules) {
-    case '49':
+    case 49:
       nodeAbi = 'electron-v1.3';
       break;
-    case '50':
+    case 50:
       nodeAbi = 'electron-v1.4';
       break;
-    case '53':
+    case 53:
       nodeAbi = 'electron-v1.6';
       break;
     default:

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -15,12 +15,16 @@ TARGETS=(
   "--target_platform=linux --runtime=electron --target=1.3.6"
   "--target_platform=linux --runtime=node --target=5.0.0"
   "--target_platform=linux --runtime=node --target=6.0.0"
+  "--target_platform=linux --runtime=electron --target=1.4.16"
   "--target_platform=linux --runtime=node --target=7.0.0"
+  "--target_platform=linux --runtime=electron --target=1.6.5"
 
   "--target_platform=darwin --runtime=electron --target=1.3.6"
   "--target_platform=darwin --runtime=node --target=5.0.0"
   "--target_platform=darwin --runtime=node --target=6.0.0"
+  "--target_platform=darwin --runtime=electron --target=1.4.16"
   "--target_platform=darwin --runtime=node --target=7.0.0"
+  "--target_platform=darwin --runtime=electron --target=1.6.5"
 )
 
 MODULE_NAMES=(


### PR DESCRIPTION
Hello,

I have added Electron 1.4 and 1.6 stable versions to the build process.
Indeed, for instance Arch Linux is using Electron 1.4 to start Atom, and Nuclide fails to initialize on such configuration.