### PR TITLE
Enable caller to use a root folder path to untie scores

### DIFF
--- a/fuzzy-native/spec/fuzzy-native-spec.js
+++ b/fuzzy-native/spec/fuzzy-native-spec.js
@@ -129,10 +129,28 @@ describe('fuzzy-native', function() {
     ]);
   });
 
-  it('breaks ties by length', function() {
+  it('breaks ties by length if root folder is not passed', function() {
     matcher.setCandidates(['123/a', '12/a', '1/a']);
     var result = matcher.match('a');
     expect(values(result)).toEqual(['1/a', '12/a', '123/a']);
+  });
+
+  it('breaks ties by distance to root folder', function() {
+    matcher.setCandidates([
+      '/A/B/C/file.js',
+      '/A/B/file.js',
+      '/A/C/D/file.js',
+      '/A/REALLY_BIG_NAME/file.js',
+      '/A/file.js',
+    ]);
+    var result = matcher.match('file', {rootPath: '/A/B/C/'});
+    expect(values(result)).toEqual([
+      '/A/B/C/file.js',
+      '/A/B/file.js',
+      '/A/file.js',
+      '/A/REALLY_BIG_NAME/file.js',
+      '/A/C/D/file.js',
+    ]);
   });
 
   it('can limit to maxResults', function() {

--- a/fuzzy-native/src/MatcherBase.cpp
+++ b/fuzzy-native/src/MatcherBase.cpp
@@ -50,8 +50,12 @@ int num_dirs(const std::string &path) {
 }
 
 int score_based_root_path(const MatchOptions &options,
-                     const MatcherBase::CandidateData &candidate) {
+                          const MatcherBase::CandidateData &candidate) {
   const std::string &root = options.root_path;
+  if (root.length() == 0) {
+    return 0;
+  }
+  
   const std::string &value = candidate.value;
 
   size_t num_common_dirs = 0;

--- a/fuzzy-native/src/MatcherBase.cpp
+++ b/fuzzy-native/src/MatcherBase.cpp
@@ -35,12 +35,52 @@ inline string str_to_lower(const std::string &s) {
   return lower;
 }
 
+bool is_slash(char c) {
+  return c == '/' || c == '\\';
+}
+
+int num_dirs(const std::string &path) {
+  int num = 0;
+  for (size_t i = 0; i < path.length(); i++) {
+    if (is_slash(path[i])) {
+      num++;
+    }
+  }
+  return num;
+}
+
+int score_based_root_path(const MatchOptions &options,
+                     const MatcherBase::CandidateData &candidate) {
+  const std::string &root = options.root_path;
+  const std::string &value = candidate.value;
+
+  size_t num_common_dirs = 0;
+  size_t i = 0;
+
+  // Count number of common directories
+  for (; i < root.length() && i < value.length(); i++) {
+    if (root[i] != value[i]) {
+      break;
+    }
+    if (is_slash(root[i])) {
+      num_common_dirs++;
+    }
+  }
+
+  if (i == root.length() && i < value.length() && is_slash(value[i])) {
+    num_common_dirs++;
+  }
+
+  return 1000 * num_common_dirs - candidate.num_dirs;
+}
+
 // Push a new entry on the heap while ensuring size <= max_results.
 void push_heap(ResultHeap &heap,
                float score,
+               int score_based_root_path,
                const std::string *value,
                size_t max_results) {
-  MatchResult result(score, value);
+  MatchResult result(score, score_based_root_path, value);
   if (heap.size() < max_results || result < heap.top()) {
     heap.push(std::move(result));
     if (heap.size() > max_results) {
@@ -102,7 +142,13 @@ void thread_worker(
         options
       );
       if (score > 0) {
-        push_heap(result, score, &candidate.value, max_results);
+        push_heap(
+          result,
+          score,
+          score_based_root_path(options, candidate),
+          &candidate.value,
+          max_results
+        );
         candidate.last_match = true;
       } else {
         candidate.last_match = false;
@@ -122,6 +168,7 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
   matchOptions.case_sensitive = options.case_sensitive;
   matchOptions.smart_case = false;
   matchOptions.max_gap = options.max_gap;
+  matchOptions.root_path = options.root_path;
 
   string new_query;
   // Ignore all whitespace in the query.
@@ -179,7 +226,13 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
       threads[i].join();
       while (thread_results[i].size()) {
         auto &top = thread_results[i].top();
-        push_heap(combined, top.score, top.value, max_results);
+        push_heap(
+          combined,
+          top.score,
+          top.score_based_root_path,
+          top.value,
+          max_results
+        );
         thread_results[i].pop();
       }
     }
@@ -204,6 +257,7 @@ void MatcherBase::addCandidate(const string &candidate) {
     data.bitmask = letter_bitmask(lowercase.c_str());
     data.lowercase = move(lowercase);
     data.last_match = true;
+    data.num_dirs = num_dirs(candidate);
     candidates_.emplace_back(move(data));
   }
 }

--- a/fuzzy-native/src/binding.cpp
+++ b/fuzzy-native/src/binding.cpp
@@ -35,6 +35,27 @@ std::string to_std_string(const v8::Local<v8::String> &v8str) {
   return str;
 }
 
+std::string get_string_property(const v8::Local<v8::Object> &object,
+                                const char *name) {
+  auto prop =
+    Nan::Get(object, Nan::New(name).ToLocalChecked());
+  if (!prop.IsEmpty()) {
+    auto propLocal = prop.ToLocalChecked();
+    if (propLocal->IsNull() || propLocal->IsUndefined()) {
+      return std::string("");
+    }
+    if (!propLocal->IsString()) {
+      std::string msg =
+        std::string("property ") +
+        name +
+        std::string(" must be a string");
+      ThrowTypeError(msg.c_str());
+    }
+    return to_std_string(propLocal->ToString());
+  }
+  return std::string("");
+}
+
 Persistent<v8::Function> MatcherConstructor;
 
 class Matcher : public ObjectWrap {
@@ -83,6 +104,7 @@ public:
       options.max_gap = get_property<int>(options_obj, "maxGap");
       options.record_match_indexes =
           get_property<bool>(options_obj, "recordMatchIndexes");
+      options.root_path = get_string_property(options_obj, "rootPath");
     }
 
     auto valueKey = New("value").ToLocalChecked();

--- a/fuzzy-native/src/score_match.h
+++ b/fuzzy-native/src/score_match.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 struct MatchOptions {
   bool case_sensitive;
   bool smart_case;
   size_t max_gap;
+  std::string root_path;
 };
 
 /**


### PR DESCRIPTION
Suppose you have the following files in your tree
- `/A/package.json`
- `/A/B/package.json`
- `/A/B/C/package.json`
- `/A/C/D/package.json`
- `/A/REALLY_BIG_NAME/package.json`

and you are editing a file in `/A/B/C` directory. If you query for
`package`, you are going to get `/A/package.json` as first suggestion,
since the current logic to break ties prefers the suggestions with few
characters. We can do better if we break the tie considering the
distance between the files suggestion to the current directory. In this
case, the suggestion should be `/A/B/C/package.json`.