### PR TITLE
Improvements to fuzzy finder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.9
+      - g++-7
       - libsecret-1-dev
 
 matrix:
@@ -15,11 +15,11 @@ matrix:
   include:
     # linux
     - os: linux   # abi 51
-      env: NODE_VERSION="7" CXX="g++-4.9"
+      env: NODE_VERSION="7" CXX="g++-7"
     - os: linux   # abi 53
-      env: NODE_VERSION="7.4" ELECTRON="1.6.5" CXX="g++-4.9"
+      env: NODE_VERSION="7.4" ELECTRON="1.6.5" CXX="g++-7"
     - os: linux   # abi 54
-      env: NODE_VERSION="7.4" ELECTRON="1.7.0" CXX="g++-4.9"
+      env: NODE_VERSION="7.4" ELECTRON="1.7.0" CXX="g++-7"
     # os x x86
     - os: osx     # abi 51
       env: NODE_VERSION="7" CXX="clang"

--- a/fuzzy-native/lib/main.js.flow
+++ b/fuzzy-native/lib/main.js.flow
@@ -4,6 +4,10 @@ export type MatcherOptions = {
   // Default: false
   caseSensitive?: boolean,
 
+  // Prefers case-sensitive matches when the query contains an uppercase letter.
+  // Default: false
+  smartCase?: boolean,
+
   // Default: infinite
   maxResults?: number,
 

--- a/fuzzy-native/spec/fuzzy-native-spec.js
+++ b/fuzzy-native/spec/fuzzy-native-spec.js
@@ -173,7 +173,7 @@ describe('fuzzy-native', function() {
     // alphabetacappa
     // _    _   _
     expect(result[2].matchIndexes).toEqual([0, 5, 9]);
-    expect(result[3].matchIndexes).toEqual([0, 5, 9]);
+    expect(result[3].matchIndexes).toEqual([4, 5, 9]);
 
     result = matcher.match('t/i/a/t/d', {recordMatchIndexes: true});
     // /this/is/a/test/dir',

--- a/fuzzy-native/spec/fuzzy-native-spec.js
+++ b/fuzzy-native/spec/fuzzy-native-spec.js
@@ -54,7 +54,7 @@ describe('fuzzy-native', function() {
     ]);
 
     // Defaults to case-insensitive matching (favouring the right case).
-    result = matcher.match('ABC');
+    result = matcher.match('ABC', {smartCase: true});
     expect(values(result)).toEqual([
       'AlphaBetaCappa',
       'abC',
@@ -89,7 +89,7 @@ describe('fuzzy-native', function() {
   });
 
   it('uses smart case', function() {
-    var result = matcher.match('ThisIsATestDir');
+    var result = matcher.match('ThisIsATestDir', {smartCase: true});
     expect(values(result)).toEqual([
       '/////ThisIsATestDir',
       'thisisatestdir',
@@ -159,7 +159,7 @@ describe('fuzzy-native', function() {
       'abC',
     ]);
 
-    result = matcher.match('ABC', {maxResults: 2});
+    result = matcher.match('ABC', {maxResults: 2, smartCase: true});
     expect(values(result)).toEqual([
       'AlphaBetaCappa',
       'abC',

--- a/fuzzy-native/src/MatcherBase.cpp
+++ b/fuzzy-native/src/MatcherBase.cpp
@@ -55,7 +55,7 @@ int score_based_root_path(const MatchOptions &options,
   if (root.length() == 0) {
     return 0;
   }
-  
+
   const std::string &value = candidate.value;
 
   size_t num_common_dirs = 0;
@@ -110,6 +110,7 @@ vector<MatchResult> finalize(const string &query,
         query.c_str(),
         query_case.c_str(),
         options,
+        0.0,
         result.matchIndexes.get()
       );
     }
@@ -132,6 +133,7 @@ void thread_worker(
   ResultHeap &result
 ) {
   int bitmask = letter_bitmask(query_case.c_str());
+  float min_score = 0.0;
   for (size_t i = start; i < end; i++) {
     auto &candidate = candidates[i];
     if (use_last_match && !candidate.last_match) {
@@ -143,7 +145,8 @@ void thread_worker(
         candidate.lowercase.c_str(),
         query.c_str(),
         query_case.c_str(),
-        options
+        options,
+        min_score
       );
       if (score > 0) {
         push_heap(
@@ -153,6 +156,9 @@ void thread_worker(
           &candidate.value,
           max_results
         );
+        if (result.size() == max_results) {
+          min_score = max(min_score, result.top().score);
+        }
         candidate.last_match = true;
       } else {
         candidate.last_match = false;

--- a/fuzzy-native/src/MatcherBase.cpp
+++ b/fuzzy-native/src/MatcherBase.cpp
@@ -186,7 +186,7 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
     if (!isspace(c)) {
       new_query += c;
     }
-    if (isupper(c) && !matchOptions.case_sensitive) {
+    if (options.smart_case && isupper(c) && !matchOptions.case_sensitive) {
       matchOptions.smart_case = true;
     }
   }

--- a/fuzzy-native/src/MatcherBase.h
+++ b/fuzzy-native/src/MatcherBase.h
@@ -7,6 +7,7 @@
 
 struct MatcherOptions {
   bool case_sensitive = false;
+  bool smart_case = false;
   size_t num_threads = 0;
   size_t max_results = 0;
   size_t max_gap = 0;

--- a/fuzzy-native/src/binding.cpp
+++ b/fuzzy-native/src/binding.cpp
@@ -137,8 +137,16 @@ public:
     if (info.Length() > 0) {
       CHECK(info[0]->IsArray(), "Expected an array of strings");
       auto arg1 = v8::Local<v8::Array>::Cast(info[0]);
+      // Create a random permutation so that candidates are shuffled.
+      std::vector<size_t> indexes(arg1->Length());
+      for (size_t i = 0; i < indexes.size(); i++) {
+        indexes[i] = i;
+        if (i > 0) {
+          std::swap(indexes[rand() % i], indexes[i]);
+        }
+      }
       matcher->impl_.reserve(matcher->impl_.size() + arg1->Length());
-      for (size_t i = 0; i < arg1->Length(); i++) {
+      for (auto i: indexes) {
         matcher->impl_.addCandidate(to_std_string(arg1->Get(i)->ToString()));
       }
     }

--- a/fuzzy-native/src/binding.cpp
+++ b/fuzzy-native/src/binding.cpp
@@ -99,6 +99,7 @@ public:
       CHECK(info[1]->IsObject(), "Second argument should be an options object");
       auto options_obj = info[1]->ToObject();
       options.case_sensitive = get_property<bool>(options_obj, "caseSensitive");
+      options.smart_case = get_property<bool>(options_obj, "smartCase");
       options.num_threads = get_property<int>(options_obj, "numThreads");
       options.max_results = get_property<int>(options_obj, "maxResults");
       options.max_gap = get_property<int>(options_obj, "maxGap");

--- a/fuzzy-native/src/score_match.cpp
+++ b/fuzzy-native/src/score_match.cpp
@@ -6,6 +6,7 @@
  * with a few modifications and extra optimizations.
  */
 
+#include <algorithm>
 #include <string>
 #include <cstring>
 

--- a/fuzzy-native/src/score_match.cpp
+++ b/fuzzy-native/src/score_match.cpp
@@ -69,7 +69,7 @@ float recursive_match(const MatchInfo &m,
   }
 
   float &memoized = m.memo[needle_idx * m.haystack_len + haystack_idx];
-  if (memoized != -1) {
+  if (memoized >= 0) {
     return memoized;
   }
 
@@ -230,7 +230,8 @@ float score_match(const char *haystack,
 #else
   float memo[memo_size];
 #endif
-  fill(memo, memo + memo_size, -1);
+  // This doesn't set the values to -2, but some negative number.
+  memset(memo, -2, sizeof(float) * memo_size);
   m.memo = memo;
 
   // Since we scaled by the length of haystack used,

--- a/fuzzy-native/src/score_match.h
+++ b/fuzzy-native/src/score_match.h
@@ -27,4 +27,5 @@ float score_match(const char *haystack,
                   const char *needle,
                   const char *needle_lower,
                   const MatchOptions &options,
+                  const float min_score,
                   std::vector<int> *match_indexes = nullptr);


### PR DESCRIPTION
Had some spare time over the weekend so I implemented some improvements that @wanderley brought up earlier:

- Track the minimum score in the result heap and stop the recursive search early if we know we can't beat the minimum score. This actually helps a lot!
- Randomly shuffle the input candidates to avoid imbalances among threads. (h/t @bolinfest)
- Make `smartcase` an option, disabled by default (this tends to confuse people, and only power users know to benefit from it).
- There was actually a pretty severe bug with gap penalties where we'd only increase the gap penalty after a character match 😮 Switched to just using a formula - the performance penalty isn't noticeable.
- `_malloca` actually requires `_freea` on Windows - but with 10000 floats (40KB) I don't think `_alloca` will ever fail. So just use that instead.
- Switch to `memset` instead of `fill` (`memset` often has builtin implementations). While memsetting to -2 doesn't actually mean -2 when the data is floats, it's still negative (which is all we care about).
- Going to try using GCC7 on Linux...

Here are some benchmarks with a production sample of ~250K files on my MacBook (4 threads):

| After | Before |
|-----------------|-------------|
|s 25ms           | s 28ms           |
|se 26ms          | se 107ms |
|see 35ms         | see 161ms  |
|seed 31ms        | seed 118ms   |
|seedt 51ms       | seedt 100ms    |
|seedti 55ms      | seedti 79ms     |
|seedtim 30ms     | seedtim 36ms      |
|seedtime 23ms    | seedtime 28ms       |
|fefi 20ms        | fefi 97ms   |
|fefil 20ms       | fefil 80ms    |
|fefile 23ms      | fefile 79ms     |
|fefilen 54ms     | fefilen 79ms      |
|fefilena 14ms    | fefilena 33ms       |
|fefilenam 8ms    | fefilenam 19ms       |
|fefilename 10ms  | fefilename 16ms          |